### PR TITLE
Switch resources to https to avoid mixed content.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
     <meta charset=utf-8 />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>scalloc</title>
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" />
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-    <script src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" />
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
     <link rel="stylesheet" href="css/main.css" />
 
     <script>


### PR DESCRIPTION
Modern browsers refuse to load insecure resources on pages served over https (aka. mixed content). This changes all resources to always be loaded via https to fix the breakage that happens when loading the project page using the following link.

https://scalloc.cs.uni-salzburg.at/