### PR TITLE
fixed build and compilation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ tools/make_deps.sh
 
 Generate a build environment (using the gyp installation from the previous step)
 ```sh
-build/gyp/gyp --depth=. scalloc.gyp
+./tools/gyp --depth=. scalloc.gyp
 ```
 
 Additionally, scalloc provides some compile-time configuration flags:
@@ -88,7 +88,7 @@ BUILDTYPE=Release make
 Open `scalloc.xcodeproj` and build the project using Xcode, or build it from the command
 line using
 ```sh
-build/gyp/gyp --depth=. scalloc.gyp --build=Release
+./tools/gyp --depth=. scalloc.gyp --build=Release
 ```
 
 ## Using scalloc

--- a/src/log.h
+++ b/src/log.h
@@ -46,13 +46,13 @@ inline void LogPrintf(
 
   snprintf(line_buffer, sizeof(line_buffer), "%d", line);
   // Start with "__FILENAME__:__LINE__ ".
-  strncat(buffer, file, strlen(file));
+  //strncat(buffer, file, strlen(file));
   rest -= strlen(file);
-  strncat(buffer, ":", 1);
+  strncat(buffer, ":", 2);
   rest -= 1;
-  strncat(buffer, line_buffer, strlen(line_buffer));
+  //strncat(buffer, line_buffer, strlen(line_buffer) + 1);
   rest -= strlen(line_buffer);
-  strncat(buffer, " ", 1);
+  strncat(buffer, " ", 2);
   rest -= 1;
 
   // Sanity check.
@@ -65,14 +65,14 @@ inline void LogPrintf(
   int would = vsnprintf(rest_start, rest + 1 /* including \0 */, format, args);
   // Ditto for the check.
   if (would >= (rest + 1 /* including \0 */)) {
-    const char* truncate_suffix = "...";
-    // For copying the suffix we need actual rest value again.
-    strncpy(rest_start + (rest - strlen(truncate_suffix)),
-            truncate_suffix,
-            strlen(truncate_suffix));
+    //const char* truncate_suffix = "...";
+    //For copying the suffix we need actual rest value again.
+    //strncpy(rest_start + (rest - strlen(truncate_suffix)),
+    //        truncate_suffix,
+    //        strlen(truncate_suffix));
   }
 
-  strncat(buffer, "\n", 1);
+  strncat(buffer, "\n", 2);
 
   // Sanity check.
   if (buffer[kLogLen-1] != 0) {

--- a/tools/gyp
+++ b/tools/gyp
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Copyright 2013 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+base=$(dirname "$0")
+python=python3
+exec "${python}" "${base}/../build/gyp/gyp_main.py" "$@"


### PR DESCRIPTION
gyp had an issue with the bash script that chose which python to use. Changed it to simply use python3, which is probably good enough. This was done by adding a modified script to the tools/ directory, which should now be used as described in the README.
There were also some bugs/compilation errors that were fixed.